### PR TITLE
Fix Buffer constructor deprecation warnings

### DIFF
--- a/lib/nilsimsa.js
+++ b/lib/nilsimsa.js
@@ -18,7 +18,7 @@ exports.Nilsimsa = class {
   }
 
   update(data) {
-    const buffer = new Buffer(data)
+    const buffer = Buffer.from(data)
     for (const ch of buffer.values()) {
       this.count += 1
       if (this.lastch1 > -1) {
@@ -70,6 +70,6 @@ exports.Nilsimsa = class {
     }
 
     code.reverse()
-    return new Buffer(code).toString(encoding)
+    return Buffer.from(code).toString(encoding)
   }
 }


### PR DESCRIPTION
Using `new Buffer()` is deprecated and node now logs the following in node 10 and 12 when used:

> (node:78060) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

The warning can easily be dropped by using the newer API according to [this deprecation guide](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/). See also [this article](https://nodesource.com/blog/understanding-the-buffer-deprecation-in-node-js-10/) for more details.

This PR replaces the 2 `new Buffer(something)` by `Buffer.from(something)` to do just that.